### PR TITLE
Fix link to Class Syntax on MDN

### DIFF
--- a/src/pages/Classes.js
+++ b/src/pages/Classes.js
@@ -62,7 +62,7 @@ In ES5, classes are written as functions, with instance methods assigned to \`My
 
 ${<EditorConsole code={classExtendsExample} title={"Inheritance"} />}
 
-For full details on the \`class\` syntax, see the [MDN reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes').
+For full details on the \`class\` syntax, see the [MDN reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes).
 `;
 
 export default props =>


### PR DESCRIPTION
removed a trailing Apostrophe so that the link actually goes to the class reference and not a 404 page.