### PR TITLE
useEffect

### DIFF
--- a/examples/files/hooks/useEffect.js
+++ b/examples/files/hooks/useEffect.js
@@ -1,31 +1,29 @@
 import React, { useState, useEffect } from 'react'
 
 const App = () => {
-  const [name, setName] = useState('Devin')
-
-  const greet = name => {
-    console.log(`Hello! ${name}`)
-  }
+  const [count, setCount] = useState(0)
+  const [increment, setIncrement] = useState(1)
 
   useEffect(() => {
-    greet(name)
+    console.log(Math.random() * 50)
   })
 
   return (
     <div>
-      <label htmlFor={'my-input'}>Enter text: </label>
-      <input
-        id={'my-input'}
-        type={'text'}
-        value={name}
-        placeholder={'Type here'}
-        onChange={event => {
-          setName(event.target.value)
+      <button
+        onClick={() => {
+          setCount(count + increment)
         }}
-      />
-      <br />
-      <br />
-      You entered: {name}
+      >
+        Current count: {count}
+      </button>
+      <button
+        onClick={() => {
+          setIncrement(increment + 1)
+        }}
+      >
+        Current increment: {increment}
+      </button>
     </div>
   )
 }

--- a/examples/files/hooks/useEffect.js
+++ b/examples/files/hooks/useEffect.js
@@ -2,28 +2,37 @@ import React, { useState, useEffect } from 'react'
 
 const App = () => {
   const [count, setCount] = useState(0)
-  const [increment, setIncrement] = useState(1)
+  const [text, setText] = useState('')
 
   useEffect(() => {
-    console.log(Math.random() * 50)
+    if (count > 0 && count % 5 == 0) {
+      alert(`${count} is divisible by 5!`)
+    }
+    console.log(`I change every time something changes: ${count} ${text}`)
+    console.log(Math.random())
   })
 
   return (
     <div>
       <button
         onClick={() => {
-          setCount(count + increment)
+          setCount(count + 1)
         }}
       >
-        Current count: {count}
+        Click HERE to increment: {count}
       </button>
-      <button
-        onClick={() => {
-          setIncrement(increment + 1)
+      <br />
+      <label htmlFor={'my-input'}>Enter text: </label>
+      <input
+        id={'my-input'}
+        type={'text'}
+        value={text}
+        onChange={(event) => {
+          setText(event.target.value)
         }}
-      >
-        Current increment: {increment}
-      </button>
+      />
+      <br />
+      You entered: {text}
     </div>
   )
 }

--- a/examples/files/hooks/useEffectWithDeps.js
+++ b/examples/files/hooks/useEffectWithDeps.js
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react'
+
+const HealthApp = () => {
+  const [steps, setSteps] = useState(25)
+  const [waterDrank, setWaterDrank] = useState(0)
+  const [ounces, setOunces] = useState(0)
+  const [firstCount, setFirstCount] = useState(0)
+  const [secondCount, setSecondCount] = useState(0)
+
+  useEffect(() => {
+    setOunces(waterDrank * 8)
+    setFirstCount(firstCount + 1)
+  }, [waterDrank])
+
+  useEffect(() => {
+    setSecondCount(secondCount + 1)
+  }, [])
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          setSteps(steps + 25)
+        }}
+      >
+        Current number of steps: {steps}
+      </button>
+      <button
+        onClick={() => {
+          setWaterDrank(waterDrank + 1)
+        }}
+      >
+        Number of water bottles drank: {waterDrank}
+      </button>
+      <br />
+      You've had {ounces} ounces of water today!
+      <br />
+      <br />
+      This is how many times: <br />
+      the first useEffect was called: {firstCount}
+      <br />
+      the second useEffect was called: {secondCount}
+    </div>
+  )
+}
+
+export default HealthApp

--- a/examples/files/hooks/useEffectWithEmptyDeps.js
+++ b/examples/files/hooks/useEffectWithEmptyDeps.js
@@ -7,8 +7,8 @@ const App = () => {
     if (count > 0 && count % 5 == 0) {
       alert(`${count} is divisible by 5!`)
     }
-    console.log(`I run every time count changes: ${count}`)
-  }, [count])
+    console.log(`I run only once: ${count}`)
+  }, [])
 
   return (
     <div>

--- a/pages/hooks/useeffect.mdx
+++ b/pages/hooks/useeffect.mdx
@@ -2,6 +2,31 @@
 title: useEffect
 ---
 
+import useEffect from '../../examples/files/hooks/useEffect.js'
+import useEffectWithDeps from '../../examples/files/hooks/useEffectWithDeps.js'
+
 # useEffect
 
-Coming soon!
+**useEffect** takes in a callback function as its first argument.  
+When the function component renders (or re-renders), the callback function that is passed to **useEffect** will run.  
+
+For example, the function inside this **useEffect** will run each time the state is changed.  
+Every time a button is clicked (or the component is re-rendered), a new random number is displayed on the console!
+
+<Example code={useEffect}/>
+
+## Dependency
+
+However, there will be times when you only want to run the function inside **useEffect** when *something specific* has changed and not every time the component renders. This will be helpful especially if you are doing time-consuming or expensive function / API calls. 
+
+**useEffect** can take in an optional second argument: an array. The values in this array act as an list of dependencies.  
+
+`useEffect(callbackFunction, optionalDependencyArray)` *useEffect returns nothing!*
+
+If the dependency array is provided, **useEffect** will activate **only** when a value in this list has changed.  
+If no dependency array is provided, **useEffect** will activate anytime the component is rendered or re-rendered (as in our above example).  
+If the dependency array is empty `[]`, useEffect will activate only once when the component first renders.
+
+In the example below, watch the state change and the counts increment respectively as we click the Buttons for `Current number of steps` and `Number of water bottles drank`, but notice that the first **useEffect** is not called when `Current number of steps` is clicked. This is because it has listed the stateful value `waterDrank` in its array of dependencies.
+
+<Example code={useEffectWithDeps}/>

--- a/pages/hooks/useeffect.mdx
+++ b/pages/hooks/useeffect.mdx
@@ -4,29 +4,39 @@ title: useEffect
 
 import useEffect from '../../examples/files/hooks/useEffect.js'
 import useEffectWithDeps from '../../examples/files/hooks/useEffectWithDeps.js'
+import useEffectWithEmptyDeps from '../../examples/files/hooks/useEffectWithEmptyDeps.js'
 
 # useEffect
 
-**useEffect** takes in a callback function as its first argument.  
-When the function component renders (or re-renders), the callback function that is passed to **useEffect** will run.  
-
-For example, the function inside this **useEffect** will run each time the state is changed.  
-Every time a button is clicked (or the component is re-rendered), a new random number is displayed on the console!
-
-<Example code={useEffect}/>
-
-## Dependency
-
-However, there will be times when you only want to run the function inside **useEffect** when *something specific* has changed and not every time the component renders. This will be helpful especially if you are doing time-consuming or expensive function / API calls. 
-
-**useEffect** can take in an optional second argument: an array. The values in this array act as an list of dependencies.  
+We use the `useEffect` for calling functions with side effects within our components. 
 
 `useEffect(callbackFunction, optionalDependencyArray)` *useEffect returns nothing!*
 
-If the dependency array is provided, **useEffect** will activate **only** when a value in this list has changed.  
-If no dependency array is provided, **useEffect** will activate anytime the component is rendered or re-rendered (as in our above example).  
-If the dependency array is empty `[]`, useEffect will activate only once when the component first renders.
+`useEffect` takes in a callback function as its first argument.  
+When the function component renders (or re-renders), the callback function that is passed to `useEffect` will run.  
+`useEffect` can also take in an optional second argument: an array. The values in this array act as a list of dependencies. 
 
-In the example below, watch the state change and the counts increment respectively as we click the Buttons for `Current number of steps` and `Number of water bottles drank`, but notice that the first **useEffect** is not called when `Current number of steps` is clicked. This is because it has listed the stateful value `waterDrank` in its array of dependencies.
+Let's take a look at an example use case. Here, we are using `useEffect` to trigger an alert (pop-up window) if `count` is divisible by 5.  
+`useEffect` is activated every time the `count` state changes because `count` is listed as a dependency.
 
 <Example code={useEffectWithDeps}/>
+
+## Undefined or Empty Dependency Array
+
+If a dependency array is not given (undefined) or is an empty array, `useEffect` will have a different behavior. 
+
+`useEffect` will trigger... 
+
+- if a value changes in the given dependency array
+- only once when the component first renders if there is an empty dependency array `[]`
+- on any and every state change or render of the component if there is no dependency array (it is undefined)
+
+Here is an example of the second bullet point, where the dependency array is an empty array. 
+`useEffect` will activate only once. 
+
+<Example code={useEffectWithEmptyDeps}/>
+
+Here is an example of the third bullet point, where the dependency array is undefined. 
+`useEffect` will trigger every time any state is changed in the component.
+
+<Example code={useEffect}/>


### PR DESCRIPTION
- Added 2 examples with `useEffect` (one introduction and one with dependencies)
- Updated `useEffect` hooks page


### Questions
- What do you think about switching the order between `useEffect` and `useReducer` ? 
I've been finding it a bit challenging to explain situations where you'd choose `useReducer` over `useState` without being able to use `useEffect`(since it hasn't been introduced yet). (I'd love to refactor the "HealthApp" with useReducer). But if you have other thoughts or ideas, that would be awesome too! 