### PR TITLE
corrected line 37

### DIFF
--- a/pages/jsx.mdx
+++ b/pages/jsx.mdx
@@ -34,7 +34,7 @@ Any children elements should go between the opening tag, `<div>`, and closing ta
 
 <Example panes={['editor', 'transpiler']} code={jsx} />
 
-> When a JSX element wraps to multiple lines, we often write it when parentheses around it, since it looks nicer.
+> When a JSX element wraps to multiple lines, we often write it with parentheses around it, since it looks nicer.
 
 ## Interpolation
 


### PR DESCRIPTION
instead of 'when', it is with
> When a JSX element wraps to multiple lines, we often write it when parentheses around it, since it looks nicer.

> When a JSX element wraps to multiple lines, we often write it with parentheses around it, since it looks nicer.